### PR TITLE
Make it go-like

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -39,7 +39,7 @@ jobs:
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           # don't set latest tag for non-main branches
-          ko build ./ \
+          ko build ./cmd/k8s-secret-sync \
             -t "${{ github.sha }}" \
             -t "${GITHUB_REF_NAME//\//-}" \
             --platform linux/amd64,linux/arm64 -B
@@ -50,7 +50,7 @@ jobs:
           KO_DOCKER_REPO: ghcr.io/jackweinbender
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
-          ko build ./ \
+          ko build ./cmd/k8s-secret-sync \
             -t "${{ github.sha }}" \
             -t "${GITHUB_REF_NAME//\//-}" \
             -t "latest" \

--- a/pkg/op/provider.go
+++ b/pkg/op/provider.go
@@ -6,14 +6,14 @@ import (
 	"os"
 
 	"github.com/1password/onepassword-sdk-go"
-	"github.com/jackweinbender/k8s-secrets-sync/shared"
+	"github.com/jackweinbender/k8s-secrets-sync/pkg/sync"
 )
 
 type secretProvider struct {
 	client *onepassword.Client
 }
 
-func NewProvider() (shared.SecretProvider, error) {
+func NewProvider() (sync.SecretProvider, error) {
 	client, err := initClient()
 	if err != nil {
 		return nil, err

--- a/pkg/sync/interfaces.go
+++ b/pkg/sync/interfaces.go
@@ -1,4 +1,4 @@
-package shared
+package sync
 
 import "context"
 


### PR DESCRIPTION
This pull request refactors the project structure and updates the main entrypoint to improve modularity and provider initialization. The changes move core packages to a new directory, update import paths, and refactor how secret providers are initialized and used in the main sync process.

**Project structure and import path updates:**
* Moved `op/provider.go` to `pkg/op/provider.go` and updated imports to use `pkg/op` and `pkg/sync` instead of the old `shared` package. The `SecretProvider` interface is now imported from `pkg/sync` (`[[1]](diffhunk://#diff-41c3760bd957bb033f5ab1b88ee83b464504cec62ee9758832ce0d0e50efd3f5L14-R17)`, `[[2]](diffhunk://#diff-73b96a26f22b761fc6460bb5da97b7375c461c79d0758eaf33cd9658c7f39dafL9-R16)`, `[[3]](diffhunk://#diff-b29a7503f8613d3c47d857f4c2071aa9f2d2e17a1ab64dfb974ec4a3992e8f25L1-R1)`).

**Provider initialization refactor:**
* Changed the provider map in `cmd/k8s-secret-sync/main.go` to use functions that return providers instead of direct instances, allowing for lazy initialization and error handling (`[cmd/k8s-secret-sync/main.goL47-R61](diffhunk://#diff-41c3760bd957bb033f5ab1b88ee83b464504cec62ee9758832ce0d0e50efd3f5L47-R61)`).
* Updated the usage of the provider map to call the provider function when fetching secrets (`[cmd/k8s-secret-sync/main.goL105-R106](diffhunk://#diff-41c3760bd957bb033f5ab1b88ee83b464504cec62ee9758832ce0d0e50efd3f5L105-R106)`).

**Entrypoint and function renaming:**
* Renamed the main entrypoint file from `main.go` to `cmd/k8s-secret-sync/main.go` and updated the Kubernetes clientset initialization function from `kubernetesClientsetInit` to `initClientSet` for clarity (`[cmd/k8s-secret-sync/main.goL156-R158](diffhunk://#diff-41c3760bd957bb033f5ab1b88ee83b464504cec62ee9758832ce0d0e50efd3f5L156-R158)`).

**Build workflow updates:**
* Updated the `.github/workflows/build-and-push.yaml` workflow to build only the `cmd/k8s-secret-sync` directory instead of the project root, ensuring the correct binary is built and pushed (`[[1]](diffhunk://#diff-0d2cab11c4e5a0cd4482d237752463d77bc7002aeacef14affe501b2d75dddbbL42-R42)`, `[[2]](diffhunk://#diff-0d2cab11c4e5a0cd4482d237752463d77bc7002aeacef14affe501b2d75dddbbL53-R53)`).